### PR TITLE
fix:アニメーションのループ回数を100に修正

### DIFF
--- a/lib/InfoPage/infoPage.dart
+++ b/lib/InfoPage/infoPage.dart
@@ -75,6 +75,7 @@ Widget _AnimationTopNewArrivalNewsText() {
           WavyAnimatedText('新着のニュース'),
         ],
         isRepeatingAnimation: true,
+        totalRepeatCount: 100,
         onTap: () {
           print("Tap Event");
         },


### PR DESCRIPTION
釣り場情報タブの文字のアニメーションのループ回数を100に修正しました。